### PR TITLE
Add verification for resource type and keyword

### DIFF
--- a/app/controllers/gitlab_controller.rb
+++ b/app/controllers/gitlab_controller.rb
@@ -1,15 +1,11 @@
 class GitlabController < ApplicationController
 
   def webhook
-    # logger.info "Params: #{params}"
-
-    basecamp = Basecamp.new(logger)
-    basecamp.request = params
-
     merge = MergeRequest.new(logger, params)
-    orchestrator = Orchestrator.new(logger, basecamp, merge)
 
-    return head(:bad_request) unless orchestrator.valid_request?
+    return head(:bad_request) unless merge.valid?
+
+    orchestrator = Orchestrator.new(logger, merge)
 
     orchestrator.process_pull_request
   end

--- a/app/lib/basecamp.rb
+++ b/app/lib/basecamp.rb
@@ -26,7 +26,7 @@ class Basecamp
   end
 
   def resources
-    links = find_links(@request["object_attributes"]["description"])
+    links = find_links(@request.description)
 
     resources = links.map { |link| @client.resource(link) }
   end
@@ -61,7 +61,7 @@ class Basecamp
 
   def match_tags(comment, tags)
     tags.each do |tag|
-      return false unless comment.content.match(/<strong.*>.*#{tag}.*<\/strong>/)
+      return false unless comment.content.match?(/<strong.*>.*#{tag}.*<\/strong>/)
     end
 
     true

--- a/app/lib/merge_request.rb
+++ b/app/lib/merge_request.rb
@@ -33,6 +33,10 @@ class MergeRequest
     end
   end
 
+  def description
+    @request['object_attributes']['description']
+  end
+
   def full_name
     "#{acronym} #{project_name}/#{id}"
   end

--- a/app/lib/orchestrator.rb
+++ b/app/lib/orchestrator.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class Orchestrator
-  def initialize(logger, basecamp, pull_request)
+  def initialize(logger, pull_request)
     @logger = logger
-    @basecamp = basecamp
+    @basecamp = Basecamp.new(logger)
+    @basecamp.request = pull_request
     @pull_request = pull_request
   end
 
@@ -12,13 +13,21 @@ class Orchestrator
   end
 
   def process_pull_request
-    @logger.info "Getting basecamp resources from request"
+    @logger.info "Getting basecamp resources from pull request #{@pull_request.full_name}"
     resources = @basecamp.resources
+    @logger.info "Basecamp resources found in description: #{resources.count}"
 
-    @logger.info "Apply TODO workflow for each resource"
     resources.each do |res|
       begin
-        @basecamp.apply_todo_workflow(res, @pull_request)
+        case res.type
+        when "Todo"
+          if found_keywords(res)
+            @logger.info "Apply TODO workflow for resource #{res.type}##{res.id}"
+            @basecamp.apply_todo_workflow(res, @pull_request)
+          else
+            @logger.info "No supported keyword found for #{res.type}##{res.id}"
+          end
+        end
       rescue Error::BasecampError => e
         @logger.info("Failed to update #{res.type}##{res.id}")
         @logger.info(e.message)
@@ -34,4 +43,28 @@ class Orchestrator
 
     nil
   end
+
+  def found_keywords(resource)
+    @logger.info "Checking if pull_request have required keyword"
+    @pull_request.description.split('\n').each do |line|
+      down_line = line.downcase
+      SUPPORTED_PR_KEYWORDS.each do |keyword|
+        return true if down_line.match?(/.*#{keyword}\s+#{resource.app_url}.*/)
+      end
+    end
+
+    false
+  end
+
+  SUPPORTED_PR_KEYWORDS = [
+    'close',
+    'closes',
+    'closed',
+    'fix',
+    'fixes',
+    'fixed',
+    'resolve',
+    'resolves',
+    'resolved',
+  ]
 end


### PR DESCRIPTION
Related to #1 

## Changes

* Restrict basecamp workflow for TODO resources
* Check if description contains one of the valid keywords on the same line as the TODO url
* Move basecamp object creation within orchestrator object
* Simplify logic in `webhook` method