### PR TITLE
Get correct merge request id.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
-    camper (0.0.8)
+    camper (0.0.9)
       httparty (~> 0.18)
       rack-oauth2 (~> 1.14)
     concurrent-ruby (1.1.7)

--- a/app/lib/basecamp.rb
+++ b/app/lib/basecamp.rb
@@ -71,7 +71,7 @@ class Basecamp
       @logger.info "Non supported status: #{pull_request.status}"
       return
     end
-    
+
     result = @client.create_comment(resource, message)
     @logger.info "Result: #{result}"
   end

--- a/app/lib/merge_request.rb
+++ b/app/lib/merge_request.rb
@@ -58,7 +58,7 @@ class MergeRequest
   end
 
   def id
-    @request['object_attributes']['id']
+    @request['object_attributes']['iid']
   end
 
   def url

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,6 +40,4 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
-
-  config.hosts << "8a81d2a5b8d4.ngrok.io"
 end


### PR DESCRIPTION
## Changes

* Switch to use `@request['object_attributes']['iid']` to get the MR number that shows in the url, instead of `@request['object_attributes']['id']` which is a global MR identifier
* Update camper to v0.0.9
* Remove `hosts` in config