### PR TITLE
Enable logging to stdout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ COPY . .
 ENTRYPOINT ["./docker/entrypoint.sh"]
 
 # Start the main process.
-CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]
+CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0", "--log-to-stdout"]


### PR DESCRIPTION
This allows to print the production logs to the stdout for easier debugging while running the docker container