### PR TITLE
Checks PR status to decide message to post

### DIFF
--- a/app/lib/merge_request.rb
+++ b/app/lib/merge_request.rb
@@ -16,18 +16,18 @@ class MergeRequest
     return @request["object_kind"] == "merge_request"
   end
 
-  def status
+  def action
     case @request['object_attributes']['action']
     when "open"
-      PullRequestStatus::OPENED
+      PullRequestAction::OPEN
     when "update"
-      PullRequestStatus::UPDATED
+      PullRequestAction::UPDATE
     when "close"
-      PullRequestStatus::CLOSED
+      PullRequestAction::CLOSE
     when "merge"
-      PullRequestStatus::MERGED
+      PullRequestAction::MERGE
     when "reopen"
-      PullRequestStatus::REOPENED
+      PullRequestAction::REOPEN
     else
       raise Error::UnexpectedMergeRequestStatus, @request
     end

--- a/app/lib/pull_request_action.rb
+++ b/app/lib/pull_request_action.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class PullRequestAction
+  OPEN = 1
+  CLOSE = 2
+  MERGE = 3
+  UPDATE = 4
+  REOPEN = 5
+end

--- a/app/lib/pull_request_status.rb
+++ b/app/lib/pull_request_status.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class PullRequestStatus
-  OPENED = 1
-  CLOSED = 2
-  MERGED = 3
-  UPDATED = 4
-  REOPENED = 5
-end

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,5 +33,7 @@ module Hermes
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    config.hosts << "44eb6e69fc75.ngrok.io"
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,5 @@ module Hermes
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
-
-    config.hosts << "44eb6e69fc75.ngrok.io"
   end
 end


### PR DESCRIPTION
Fix #15 

## Changes

* Exclude **Close** and **Reopen** actions from checks for messages in To-do. This implies that these messages will be posted always
* Add new linking comment when the To-do being referenced is already completed
* Rename `PullRequestStatus` to `PullRequestAction`
